### PR TITLE
[FIXED] ugt->ult

### DIFF
--- a/test/test1_expected_output.txt
+++ b/test/test1_expected_output.txt
@@ -1,7 +1,7 @@
 define i64 @myfunc(i64 %x, i64 %y) {
 entry:
-  %ugttmp = icmp ugt i64 %x, %y
-  %cast_i1_to_i64 = sext i1 %ugttmp to i64
+  %ulttmp = icmp ult i64 %x, %y
+  %cast_i1_to_i64 = sext i1 %ulttmp to i64
   ret i64 %cast_i1_to_i64
 }
 Wrote output.o


### PR DESCRIPTION
## Overview
[test/test1_expected_output.txt](https://github.com/yamaguchi1024/mc-lang-3/blob/c9a757aa56cd488192b3fd255e81b496ce747ea6/test/test1_expected_output.txt#L3) might be wrong.
According to [llvm::CmpInst Class Reference](https://llvm.org/doxygen/classllvm_1_1CmpInst.html#a283f9a5d4d843d20c40bb4d3e364bb05), "UGT" stands for "unsigned greater than".
Thus, the second line should be printed `%ulttmp = icmp ult i64 %x %y` because it is used `<` in [test1.mc](https://github.com/yamaguchi1024/mc-lang-3/blob/c9a757aa56cd488192b3fd255e81b496ce747ea6/test/test1.mc#L2). 




## Changes
 - [x] replace `ugt` for `ult`